### PR TITLE
Spawn and kill scanner process

### DIFF
--- a/lib/radbeacon/le_scanner.rb
+++ b/lib/radbeacon/le_scanner.rb
@@ -16,7 +16,6 @@ module Radbeacon
           Process.wait(pid)
         end
       rescue Timeout::Error
-        puts 'Scan process not finished in time, killing it'
         Process.kill('INT', pid)
       end
       wout.close


### PR DESCRIPTION
The `hcitool lescan` process wasn't always killing itself properly (the process will run forever until it is interrupted) on the ZBOX with the back tick shortcut:

`sudo hcitool lescan & sleep #{@duration}; sudo kill -2 $!`

 Now instead of this it is being spawned as a separate process and then killed when the timeout is reached.