### PR TITLE
Add options attribute for mac filter and hcitool-duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ An (optional) `options` hash is available as an attribute on the `Scanner` class
   options[:filter_mac] = ["11:22:33:44:55:66", "55:66:77:88:99:00"]
   ```
 
-- `:hcitool_duration` - Use the custom hcitool-duration binary that adds a duration option to the `hcitool lescan` command.  To use this you must copy the new hcitool binary over the standard one (located at `/usr/bin/hcitool` on the ZBOX for example).
+- `:enable_hcitool_duration` - Use the custom hcitool-duration binary that adds a duration option to the `hcitool lescan` command.  To use this you must copy the new hcitool binary over the standard one (located at `/usr/bin/hcitool` on the ZBOX for example).
 
   ```
-  options[:hcitool_duration] = true
+  options[:enable_hcitool_duration] = true
   ```
 
 #Configuring

--- a/README.md
+++ b/README.md
@@ -13,6 +13,22 @@ scanner = Radbeacon::Scanner.new(10)
 radbeacons = scanner.scan
 ```
 
+#### Scan Options
+
+An (optional) `options` hash is available as an attribute on the `Scanner` class.  Below are the following options that can be used:
+
+- `:filter_mac` - Specify an array of MAC addresses that the scanner will filter for when doing a scan
+
+  ```
+  options[:filter_mac] = ["11:22:33:44:55:66", "55:66:77:88:99:00"]
+  ```
+
+- `:hcitool_duration` - Use the custom hcitool-duration binary that adds a duration option to the `hcitool lescan` command.  To use this you must copy the new hcitool binary over the standard one (located at `/usr/bin/hcitool` on the ZBOX for example).
+
+  ```
+  options[:hcitool_duration] = true
+  ```
+
 #Configuring
 
 All identifiers and other parameters are attributes on the `Radbeacon::Usb` class:

--- a/lib/radbeacon/le_scanner.rb
+++ b/lib/radbeacon/le_scanner.rb
@@ -31,7 +31,7 @@ module Radbeacon
 
     def passive_scan
       devices = Array.new
-      if @options[:hcitool_duration] == true
+      if @options[:enable_hcitool_duration] == true
         scan_output = self.scan_command_duration
       else
         scan_output = self.scan_command

--- a/lib/radbeacon/le_scanner.rb
+++ b/lib/radbeacon/le_scanner.rb
@@ -1,10 +1,11 @@
 module Radbeacon
 
   class LeScanner
-    attr_accessor :duration
+    attr_accessor :duration, :options
 
     def initialize(duration = 5)
       @duration = duration
+      @options = {}
     end
 
     def scan_command
@@ -24,17 +25,28 @@ module Radbeacon
       scan_output
     end
 
+    def scan_command_duration
+      `sudo hcitool lescan --duration #{@duration}`
+    end
+
     def passive_scan
       devices = Array.new
-      scan_output = self.scan_command
+      if @options[:hcitool_duration] == true
+        scan_output = self.scan_command_duration
+      else
+        scan_output = self.scan_command
+      end
       scan_output.each_line do |line|
         result = line.scan(/^([A-F0-9:]{15}[A-F0-9]{2}) (.*)$/)
         if !result.empty?
           mac_address = result[0][0]
           name = result[0][1]
           if !devices.find {|s| s.mac_address == mac_address}
-            device = BluetoothLeDevice.new(mac_address, name)
-            devices << device
+            filter_mac = @options[:filter_mac]
+            if !filter_mac or (filter_mac.include?(mac_address) if filter_mac.is_a?(Array))
+              device = BluetoothLeDevice.new(mac_address, name)
+              devices << device
+            end
           end
         end
       end

--- a/lib/radbeacon/scanner.rb
+++ b/lib/radbeacon/scanner.rb
@@ -16,6 +16,11 @@ module Radbeacon
       radbeacons
     end
 
+    def fetch(mac_address)
+      dev = BluetoothLeDevice.new(mac_address, nil)
+      radbeacon_check(dev) if dev.fetch_characteristics
+    end
+
     def radbeacon_check(device)
       radbeacon = nil
       case device.values[C_DEVICE_NAME]


### PR DESCRIPTION
This adds an (optional) `options` hash as an attribute to the `LeScanner` class that currently respects two options:

- `:filter_mac` - Specify an array of MAC addresses that the scanner will filter for when doing a scan

  ```
  options[:filter_mac] = ["11:22:33:44:55:66", "55:66:77:88:99:00"]
  ```

- `:hcitool_duration` - Use the custom hcitool-duration binary that adds a duration option to the `hcitool lescan` command.  To use this you must copy the new hcitool binary over the standard one (located at `/usr/bin/hcitool` on the ZBOX for example).

  ```
  options[:hcitool_duration] = true
  ```