### PR TITLE
Add a fetch method

### DIFF
--- a/lib/radbeacon/scanner.rb
+++ b/lib/radbeacon/scanner.rb
@@ -17,12 +17,8 @@ module Radbeacon
     end
 
     def fetch(mac_address)
-      radbeacon = nil
       dev = BluetoothLeDevice.new(mac_address, nil)
-      if dev.fetch_characteristics
-        radbeacon = radbeacon_check(dev)
-      end
-      radbeacon
+      radbeacon_check(dev) if dev.fetch_characteristics
     end
 
     def radbeacon_check(device)

--- a/lib/radbeacon/scanner.rb
+++ b/lib/radbeacon/scanner.rb
@@ -16,6 +16,15 @@ module Radbeacon
       radbeacons
     end
 
+    def fetch(mac_address)
+      radbeacon = nil
+      dev = BluetoothLeDevice.new(mac_address, nil)
+      if dev.fetch_characteristics
+        radbeacon = radbeacon_check(dev)
+      end
+      radbeacon
+    end
+
     def radbeacon_check(device)
       radbeacon = nil
       case device.values[C_DEVICE_NAME]


### PR DESCRIPTION
The fetch method returns a `Radbeacon::Usb` object for a given mac address.  It returns `nil` if the fetch fails.