### PR TITLE
Characteristics timeout, only create valid Usb objects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    radbeacon (0.1.0)
+    radbeacon (0.1.1)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ scanner = Radbeacon::Scanner.new(10)
 radbeacons = scanner.scan
 ```
 
+There is also a `fetch` method that returns a `Radbeacon::Usb` object for a given MAC address.
+
+```
+radbeacon = scanner.fetch("11:22:33:44:55:66")
+```
+
 #### Scan Options
 
 An (optional) `options` hash is available as an attribute on the `Scanner` class.  Below are the following options that can be used:

--- a/lib/radbeacon/bluetooth_le_device.rb
+++ b/lib/radbeacon/bluetooth_le_device.rb
@@ -56,7 +56,7 @@ module Radbeacon
       characteristics_command_str = "gatttool -b #{@mac_address} --characteristics 2>&1"
       pid = Process.spawn(characteristics_command_str, :out => wout)
       begin
-        Timeout.timeout(2) do
+        Timeout.timeout(5) do
           Process.wait(pid)
         end
       rescue Timeout::Error

--- a/lib/radbeacon/bluetooth_le_device.rb
+++ b/lib/radbeacon/bluetooth_le_device.rb
@@ -110,8 +110,9 @@ module Radbeacon
             @characteristics.each do |char|
               input.puts "char-read-hnd #{char['value_handle']}"
               if output.expect(/Characteristic value\/descriptor: /, TIMEOUT)
-                value = output.expect(/^[0-9a-f\s]+\n/, TIMEOUT)
-                @values[char['value_handle']] = value.first.strip
+                if value = output.expect(/^[0-9a-f\s]+\n/, TIMEOUT)
+                  @values[char['value_handle']] = value.first.strip
+                end
               end
             end
             result = true

--- a/lib/radbeacon/scanner.rb
+++ b/lib/radbeacon/scanner.rb
@@ -5,15 +5,9 @@ module Radbeacon
     RADBEACON_USB = "52 61 64 42 65 61 63 6f 6e 20 55 53 42"
 
     def scan
-      radbeacons = Array.new
       devices = super
-      devices.each do |dev|
-        radbeacon = radbeacon_check(dev)
-        if radbeacon
-          radbeacons << radbeacon
-        end
-      end
-      radbeacons
+      radbeacons = devices.map { |dev| radbeacon_check(dev) }
+      radbeacons.compact
     end
 
     def fetch(mac_address)
@@ -25,7 +19,7 @@ module Radbeacon
       radbeacon = nil
       case device.values[C_DEVICE_NAME]
       when RADBEACON_USB
-        radbeacon = Usb.new(device)
+        radbeacon = Usb.create_if_valid(device)
       end
       radbeacon
     end

--- a/lib/radbeacon/usb.rb
+++ b/lib/radbeacon/usb.rb
@@ -73,7 +73,7 @@ module Radbeacon
       @minor = bytes_to_major_minor(device.values[GATT_MINOR])
       @power = bytes_to_power(device.values[GATT_POWER])
       @tx_power = TRANSMIT_POWER_VALUES.key(device.values[GATT_TXPOWER])
-      @adv_rate = ADVERTISING_RATE_VALUES.key(device.values[GATT_INTERVAL].delete(' '))
+      @adv_rate = ADVERTISING_RATE_VALUES.key(device.values[GATT_INTERVAL].delete(' ')) if device.values[GATT_INTERVAL]
       @beacon_type = BEACON_TYPES.key(device.values[GATT_BCTYPE])
     end
 

--- a/lib/radbeacon/usb.rb
+++ b/lib/radbeacon/usb.rb
@@ -61,6 +61,15 @@ module Radbeacon
     attr_reader :mac_address, :errors, :dev_model, :dev_id, :dev_version
     attr_accessor :dev_name, :uuid, :major, :minor, :power, :tx_power, :adv_rate, :beacon_type
 
+    def self.create_if_valid(device)
+      # Check everything
+      required_attrs = [GATT_DEV_MODEL, GATT_DEV_ID, GATT_FWVERSION, GATT_DEV_NAME,
+        GATT_UUID, GATT_MAJOR, GATT_MINOR, GATT_POWER, GATT_TXPOWER, GATT_INTERVAL, GATT_BCTYPE]
+      if required_attrs.all? { |key| device.values[key] }
+        self.new(device)
+      end
+    end
+
     def initialize(device)
       @errors = []
       @mac_address = device.mac_address
@@ -73,7 +82,7 @@ module Radbeacon
       @minor = bytes_to_major_minor(device.values[GATT_MINOR])
       @power = bytes_to_power(device.values[GATT_POWER])
       @tx_power = TRANSMIT_POWER_VALUES.key(device.values[GATT_TXPOWER])
-      @adv_rate = ADVERTISING_RATE_VALUES.key(device.values[GATT_INTERVAL].delete(' ')) if device.values[GATT_INTERVAL]
+      @adv_rate = ADVERTISING_RATE_VALUES.key(device.values[GATT_INTERVAL].delete(' '))
       @beacon_type = BEACON_TYPES.key(device.values[GATT_BCTYPE])
     end
 

--- a/lib/radbeacon/utils.rb
+++ b/lib/radbeacon/utils.rb
@@ -2,39 +2,39 @@ module Radbeacon
   module Utils
 
     def text_to_bytes(text)
-      text.unpack('H*')[0]
+      text.unpack('H*')[0] if text
     end
 
     def bytes_to_text(bytes)
-      [bytes.delete(' ')].pack('H*').gsub(/\x00/,'')
+      [bytes.delete(' ')].pack('H*').gsub(/\x00/,'') if bytes
     end
 
     def uuid_to_bytes(uuid)
-      uuid.gsub(/-/, '')
+      uuid.gsub(/-/, '') if uuid
     end
 
     def bytes_to_uuid(bytes)
-      bytes.delete(' ').sub(/([a-fA-F0-9]{8})([a-fA-F0-9]{4})([a-fA-F0-9]{4})([a-fA-F0-9]{4})([a-fA-F0-9]{12})/, '\1-\2-\3-\4-\5').upcase
+      bytes.delete(' ').sub(/([a-fA-F0-9]{8})([a-fA-F0-9]{4})([a-fA-F0-9]{4})([a-fA-F0-9]{4})([a-fA-F0-9]{12})/, '\1-\2-\3-\4-\5').upcase if bytes
     end
 
     def major_minor_to_bytes(value)
-      sprintf("%04x", value.to_i)
+      sprintf("%04x", value.to_i) if value
     end
 
     def bytes_to_major_minor(bytes)
-      bytes.delete(' ').to_i(16)
+      bytes.delete(' ').to_i(16) if bytes
     end
 
     def power_to_bytes(power)
-      sprintf("%x", power.to_i + 256)
+      sprintf("%x", power.to_i + 256) if power
     end
 
     def bytes_to_power(bytes)
-      bytes.to_i(16) - 256
+      bytes.to_i(16) - 256 if bytes
     end
 
     def pin_to_bytes(pin)
-      pin.unpack('H*')[0]
+      pin.unpack('H*')[0] if pin
     end
 
   end

--- a/lib/radbeacon/utils.rb
+++ b/lib/radbeacon/utils.rb
@@ -2,39 +2,39 @@ module Radbeacon
   module Utils
 
     def text_to_bytes(text)
-      text.unpack('H*')[0] if text
+      text.unpack('H*')[0]
     end
 
     def bytes_to_text(bytes)
-      [bytes.delete(' ')].pack('H*').gsub(/\x00/,'') if bytes
+      [bytes.delete(' ')].pack('H*').gsub(/\x00/,'')
     end
 
     def uuid_to_bytes(uuid)
-      uuid.gsub(/-/, '') if uuid
+      uuid.gsub(/-/, '')
     end
 
     def bytes_to_uuid(bytes)
-      bytes.delete(' ').sub(/([a-fA-F0-9]{8})([a-fA-F0-9]{4})([a-fA-F0-9]{4})([a-fA-F0-9]{4})([a-fA-F0-9]{12})/, '\1-\2-\3-\4-\5').upcase if bytes
+      bytes.delete(' ').sub(/([a-fA-F0-9]{8})([a-fA-F0-9]{4})([a-fA-F0-9]{4})([a-fA-F0-9]{4})([a-fA-F0-9]{12})/, '\1-\2-\3-\4-\5').upcase
     end
 
     def major_minor_to_bytes(value)
-      sprintf("%04x", value.to_i) if value
+      sprintf("%04x", value.to_i)
     end
 
     def bytes_to_major_minor(bytes)
-      bytes.delete(' ').to_i(16) if bytes
+      bytes.delete(' ').to_i(16)
     end
 
     def power_to_bytes(power)
-      sprintf("%x", power.to_i + 256) if power
+      sprintf("%x", power.to_i + 256)
     end
 
     def bytes_to_power(bytes)
-      bytes.to_i(16) - 256 if bytes
+      bytes.to_i(16) - 256
     end
 
     def pin_to_bytes(pin)
-      pin.unpack('H*')[0] if pin
+      pin.unpack('H*')[0]
     end
 
   end

--- a/lib/radbeacon/version.rb
+++ b/lib/radbeacon/version.rb
@@ -1,3 +1,3 @@
 module Radbeacon
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/le_scanner_spec.rb
+++ b/spec/le_scanner_spec.rb
@@ -2,15 +2,23 @@ require 'spec_helper'
 require 'radbeacon'
 
 RSpec.describe Radbeacon::LeScanner do
-  describe '#scan' do
-    scanner = Radbeacon::LeScanner.new(5)
-    devices = scanner.scan
+  def mock_scanner
+    allow_any_instance_of(Radbeacon::LeScanner).to receive(:scan_command).and_return("LE Scan ...\n00:07:80:03:88:99 (unknown)\n00:07:80:15:74:5B (unknown)\n00:07:80:15:74:5B (unknown)")
+    allow_any_instance_of(Radbeacon::BluetoothLeDevice).to receive(:fetch_characteristics).and_return(true)
+  end
 
+  describe '#scan' do
     it "scans for beacons" do
+      mock_scanner
+      scanner = Radbeacon::LeScanner.new
+      devices = scanner.scan
       expect(devices.length).to be > 0
     end
 
     it "filters out duplicate beacons in one scan" do
+      mock_scanner
+      scanner = Radbeacon::LeScanner.new
+      devices = scanner.scan
       expect(devices.uniq.length).to eq devices.length
     end
   end

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+require 'radbeacon'
+
+RSpec.describe Radbeacon::Scanner do
+
+  let(:test_device) {double(:bluetooth_le_device).as_null_object}
+  let(:test_usb) {double(:usb).as_null_object}
+
+  def mock_scanner
+    allow_any_instance_of(Radbeacon::LeScanner).to receive(:scan).and_return([test_device])
+    allow(Radbeacon::Usb).to receive(:create_if_valid).and_return(test_usb)
+    allow(Radbeacon::BluetoothLeDevice).to receive(:new).and_return(test_device)
+    allow(test_device).to receive(:fetch_characteristics).and_return(true)
+  end
+
+  describe '#scan' do
+    it "returns a radbeacon when given a BluetoothLeDevice object representing a RadBeacon" do
+      mock_scanner
+      expect(test_device).to receive(:values).at_least(:once).and_return({"0x0003"=>"52 61 64 42 65 61 63 6f 6e 20 55 53 42"})
+      scanner = Radbeacon::Scanner.new
+      radbeacons = scanner.scan
+      expect(radbeacons.count).to eq(1)
+    end
+
+    it "returns nil when given a BluetoothLeDevice object that isn't a RadBeacon" do
+      mock_scanner
+      expect(test_device).to receive(:values).at_least(:once).and_return({"0x0003"=>"de ad be ef"})
+      scanner = Radbeacon::Scanner.new
+      radbeacons = scanner.scan
+      expect(radbeacons.empty?).to eq(true)
+    end
+  end
+
+  describe '#fetch' do
+    it "returns a radbeacon when given a BluetoothLeDevice object representing a RadBeacon" do
+      mock_scanner
+      expect(test_device).to receive(:values).at_least(:once).and_return({"0x0003"=>"52 61 64 42 65 61 63 6f 6e 20 55 53 42"})
+      scanner = Radbeacon::Scanner.new
+      radbeacon = scanner.fetch("11:22:33:44:55:66")
+      expect(radbeacon.nil?).to eq(false)
+    end
+
+    it "returns nil when given a BluetoothLeDevice object that isn't a RadBeacon" do
+      mock_scanner
+      expect(test_device).to receive(:values).at_least(:once).and_return({"0x0003"=>"de ad be ef"})
+      scanner = Radbeacon::Scanner.new
+      radbeacon = scanner.fetch("11:22:33:44:55:66")
+      expect(radbeacon.nil?).to eq(true)
+    end  end
+end

--- a/spec/usb_spec.rb
+++ b/spec/usb_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'radbeacon'
+
+RSpec.describe Radbeacon::Usb do
+
+  let(:test_device) {Radbeacon::BluetoothLeDevice.new("11:22:33:44:55:66", "Test Device")}
+
+  VALID_VALUES = {"0x0003"=>"52 61 64 42 65 61 63 6f 6e 20 55 53 42", "0x0006"=>"00 00",
+    "0x000a"=>"52 61 64 69 75 73 20 4e 65 74 77 6f 72 6b 73 2c 20 49 6e 63 2e", "0x000d"=>"30 30 30 31", "0x0010"=>"30 30 30 30",
+    "0x0013"=>"32 2e 30", "0x0017"=>"52 61 64 42 65 61 63 6f 6e 20 55 53 42 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00",
+    "0x001a"=>"30 30 30 37 38 30 31 35 37 34 35 62", "0x001d"=>"5a 42 4f 58 5f 38 36 37 5f 35 33 30 39 00 00 00 00 00 00 00 00 00
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00", "0x0020"=>"84 2a f9 c4 08 f5 11 e3 92 82 f2 3c 91 ae c0 5e", "0x0023"=>"00 04",
+    "0x0026"=>"14 bd", "0x0029"=>"be", "0x002c"=>"0f", "0x002f"=>"80 00", "0x0032"=>"00 00 00 00", "0x003e"=>"03",
+    "0x0041"=>"32 2e 32 00 00 00 00", "0x0044"=>"00 00 00 00", "0x0047"=>"00"}
+  NIL_VALUES = {"0x0003"=>nil, "0x0006"=>nil, "0x000a"=>nil, "0x000d"=>nil, "0x0010"=>nil,
+    "0x0013"=>nil, "0x0017"=>nil, "0x001a"=>nil, "0x001d"=>nil, "0x0020"=>nil, "0x0023"=>nil,
+    "0x0026"=>nil, "0x0029"=>nil, "0x002c"=>nil, "0x002f"=>nil, "0x0032"=>nil, "0x003e"=>nil,
+    "0x0041"=>nil, "0x0044"=>nil, "0x0047"=>nil}
+
+  describe '#self.create_if_valid' do
+    it "creates a radbeacon object given a valid BluetoothLeDevice" do
+      expect(test_device).to receive(:values).at_least(:once).and_return(VALID_VALUES)
+      radbeacon = Radbeacon::Usb.create_if_valid(test_device)
+      expect(radbeacon.class).to eq(Radbeacon::Usb)
+    end
+
+    it "returns nil given an invalid BluetoothLeDevice" do
+      expect(test_device).to receive(:values).at_least(:once).and_return(NIL_VALUES)
+      radbeacon = Radbeacon::Usb.create_if_valid(test_device)
+      expect(radbeacon).to eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
Sometimes the `gatttool --characteristics` command will hang and never return.  To handle this, a five second timeout is added to terminate the `gatttool` process if it has taken too long to exit.

Also, to avoid trying to create a `Radbeacon::Usb` object from a `BluetoothLeDevice` with missing characteristic values (presumably from a failed read), a `create_if_valid` method has been added that validates the `BluetoothLeDevice` before constructing a `Radbeacon::Usb` from it.

This also adds more tests and reworks existing tests to run on any platform.

