### PR TITLE
Fix homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ cprun.sh
 yell.rb
 yeller.rb
 .DS_Store
+pkg/

--- a/radbeacon.gemspec
+++ b/radbeacon.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["support@radiusnetworks.com"]
 
   spec.summary       = %q{Provides RadBeacon (BLE Proximity Beacon) scanning and configuring capabilities on a linux machine.}
-  spec.homepage      = "www.radiusnetworks.com"
+  spec.homepage      = "http://www.radiusnetworks.com"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }


### PR DESCRIPTION
This makes it so you can run `rake build` to produce a `.gem` file.  I'd like to be able to do this so I can package it up as part of an openwrt image.  On first boot, it would install the gem from the `.gem` package.