### PR TITLE
Compatibility fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-<img src="http://i.imgur.com/gI6paLj.jpg" style="float:left" height="200">
-
 # What's all this then?
 
 A ruby gem that provides RadBeacon scanning and configuring capabilities on a linux machine.  Currently the only supported beacon type is RadBeacon USB.  

--- a/lib/radbeacon/bluetooth_le_device.rb
+++ b/lib/radbeacon/bluetooth_le_device.rb
@@ -1,5 +1,6 @@
 require 'pty'
 require 'expect'
+require 'timeout'
 
 module Radbeacon
   class BluetoothLeDevice

--- a/lib/radbeacon/le_scanner.rb
+++ b/lib/radbeacon/le_scanner.rb
@@ -1,3 +1,5 @@
+require 'timeout'
+
 module Radbeacon
 
   class LeScanner

--- a/lib/radbeacon/version.rb
+++ b/lib/radbeacon/version.rb
@@ -1,3 +1,3 @@
 module Radbeacon
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
Adds require statements for 'timeout' that are needed for older ruby versions (e.g., 1.9.3)