### PR TITLE
Bump version for patch release v0.1.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    radbeacon (0.1.2)
+    radbeacon (0.1.3)
 
 GEM
   remote: https://rubygems.org/
@@ -32,4 +32,4 @@ DEPENDENCIES
   rspec (~> 3.2)
 
 BUNDLED WITH
-   1.10.6
+   1.12.4

--- a/lib/radbeacon/version.rb
+++ b/lib/radbeacon/version.rb
@@ -1,3 +1,3 @@
 module Radbeacon
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
Incorporates @cupakromer's ruby warning fixes from #12
